### PR TITLE
Updated baseurl to ShakeCast_V3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ host: 127.0.0.1
 port: 4005
 # the port where the preview is rendered. You can leave this as is unless you have other Jekyll builds using this same port that might cause conflicts. in that case, use another port such as 4006.
 
-baseurl: "/ShakeCast" # the subpath of your site, e.g. /blog
+baseurl: "/ShakeCast_V3" # the subpath of your site, e.g. /blog
 
 exclude:
   - .idea/

--- a/apidocs/_sources/index.txt
+++ b/apidocs/_sources/index.txt
@@ -16,7 +16,7 @@ pyCast Developer Manual
    db.rst
    server.rst
    cli.rst
-   User and Admin Docs <http://klin-usgs.github.io/ShakeCast>
+   User and Admin Docs </ShakeCast_V3/#http://>
 
 .. Indices and tables
 .. ==================

--- a/apidocs/app.html
+++ b/apidocs/app.html
@@ -88,7 +88,7 @@
 <li class="toctree-l1"><a class="reference internal" href="db.html">Database API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             

--- a/apidocs/cli.html
+++ b/apidocs/cli.html
@@ -87,7 +87,7 @@
 <li class="toctree-l1"><a class="reference internal" href="db.html">Database API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1 current"><a class="current reference internal" href="">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             

--- a/apidocs/db.html
+++ b/apidocs/db.html
@@ -92,7 +92,7 @@
 </li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             

--- a/apidocs/functions.html
+++ b/apidocs/functions.html
@@ -91,7 +91,7 @@
 <li class="toctree-l1"><a class="reference internal" href="db.html">Database API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             

--- a/apidocs/genindex.html
+++ b/apidocs/genindex.html
@@ -87,7 +87,7 @@
 <li class="toctree-l1"><a class="reference internal" href="db.html">Database API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             

--- a/apidocs/index.html
+++ b/apidocs/index.html
@@ -87,7 +87,7 @@
 <li class="toctree-l1"><a class="reference internal" href="db.html">Database API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             
@@ -154,7 +154,7 @@
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 </div>
 </div>

--- a/apidocs/objects.html
+++ b/apidocs/objects.html
@@ -88,7 +88,7 @@
 <li class="toctree-l1"><a class="reference internal" href="db.html">Database API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             

--- a/apidocs/py-modindex.html
+++ b/apidocs/py-modindex.html
@@ -89,7 +89,7 @@
 <li class="toctree-l1"><a class="reference internal" href="db.html">Database API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             

--- a/apidocs/search.html
+++ b/apidocs/search.html
@@ -86,7 +86,7 @@
 <li class="toctree-l1"><a class="reference internal" href="db.html">Database API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="server.html">Server Documentation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             

--- a/apidocs/server.html
+++ b/apidocs/server.html
@@ -93,7 +93,7 @@
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="cli.html">CLI Documentation</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://klin-usgs.github.io/ShakeCast">User and Admin Docs</a></li>
+<li class="toctree-l1"><a class="reference external" href="/ShakeCast_V3/#http://">User and Admin Docs</a></li>
 </ul>
 
             


### PR DESCRIPTION
Updated baseurl variable in _config.yml to ShakeCast_V3

Rebuilt sphinx docs with relative link to Jekyll docs -- This way, we don't have to change anything when we switch to USGS GitHub domain
